### PR TITLE
Ugly 'selector leak' compiler warning & Other

### DIFF
--- a/ITSidebar/ITAppDelegate.m
+++ b/ITSidebar/ITAppDelegate.m
@@ -68,8 +68,8 @@
 // ****************************************** We can use
 // NSMatrix Target Action
 - (IBAction)sidebarChanged:(ITSidebar *)sender {
-    NSLog(@"%@: %d", [sender selectedItem], [sender selectedIndex]);
-    [self.label setStringValue:[NSString stringWithFormat:@"%d", [sender selectedIndex]]];
+    NSLog(@"%@: %lu", [sender selectedItem], (unsigned long)[sender selectedIndex]);
+    [self.label setStringValue:[NSString stringWithFormat:@"%lu", (unsigned long)[sender selectedIndex]]];
 }
 
 // ****************************************** OOOOOOOR

--- a/ITSidebar/ITSidebar.h
+++ b/ITSidebar/ITSidebar.h
@@ -34,7 +34,7 @@
 @property (nonatomic) NSColor *backgroundColor;
 @property (nonatomic) NSScrollerKnobStyle scrollerKnobStyle;
 @property (nonatomic) ITSidebarItemCell *selectedItem;
-@property (nonatomic) int selectedIndex;
+@property (nonatomic) NSUInteger selectedIndex;
 @property (nonatomic) BOOL allowsEmptySelection;
 
 + (Class)sidebarItemCellClass;

--- a/ITSidebar/ITSidebar.m
+++ b/ITSidebar/ITSidebar.m
@@ -157,12 +157,12 @@
 - (void)setSelectedItem:(ITSidebarItemCell *)selectedItem {
     self.selectedIndex = [[self.matrix cells] indexOfObject:selectedItem];
 }
-- (int)selectedIndex {
+- (NSUInteger)selectedIndex {
     ITSidebarItemCell *cell = [self selectedItem];
     return (int)[self.matrix.cells indexOfObject:cell];
 }
-- (void)setSelectedIndex:(int)index {
-    if (index >= 0 && index < self.matrix.cells.count) {
+- (void)setSelectedIndex:(NSUInteger)index {
+    if (index < self.matrix.cells.count) {
         [self.matrix selectCell:[self.matrix.cells objectAtIndex:index]];
         
         // Again, no action

--- a/ITSidebar/ITSidebar.m
+++ b/ITSidebar/ITSidebar.m
@@ -248,9 +248,10 @@
 #pragma mark ITSidebar Target Action
 - (IBAction)matrixCallback:(id)sender {
     if ([self.target respondsToSelector:self.action]) {
+        //Ideally NSInvocation needs to be usd here but, afterDelay:0 is just as good (for now) :)
             [self.target performSelector:self.action withObject:self afterDelay:0];
     } else {
-            //Ideally NSInvocation needs to be usd here but this is just as good (for now) :)
+        //Ideally NSInvocation needs to be usd here but, afterDelay:0 is just as good (for now) :)
                 [self.selectedItem.target performSelector:self.selectedItem.action withObject:self.selectedItem afterDelay:0];
     }
 }

--- a/ITSidebar/ITSidebar.m
+++ b/ITSidebar/ITSidebar.m
@@ -252,14 +252,8 @@
             [self.target performSelector:self.action withObject:self];
         );
     } else {
-        // Very ugly hack, because again the action is not invoked by the NSButtonCell
-        // NSButtonCell's performClick: causes some unexpected behaviour.
-        // If anyone finds another way of doing this, let me know over Github ;)
-        if ([self.selectedItem.target respondsToSelector:self.selectedItem.action]) {
-            SuppressPerformSelectorLeakWarning(
-                [self.selectedItem.target performSelector:self.selectedItem.action withObject:self.selectedItem];
-            );
-        }
+            //Ideally NSInvocation needs to be usd here but this is just as good (for now) :)
+                [self.selectedItem.target performSelector:self.selectedItem.action withObject:self.selectedItem afterDelay:0];
     }
 }
 - (void)setTarget:(id)target {

--- a/ITSidebar/ITSidebar.m
+++ b/ITSidebar/ITSidebar.m
@@ -248,9 +248,7 @@
 #pragma mark ITSidebar Target Action
 - (IBAction)matrixCallback:(id)sender {
     if ([self.target respondsToSelector:self.action]) {
-        SuppressPerformSelectorLeakWarning(
-            [self.target performSelector:self.action withObject:self];
-        );
+            [self.target performSelector:self.action withObject:self afterDelay:0];
     } else {
             //Ideally NSInvocation needs to be usd here but this is just as good (for now) :)
                 [self.selectedItem.target performSelector:self.selectedItem.action withObject:self.selectedItem afterDelay:0];


### PR DESCRIPTION
I've managed to get that 'ugly' compiler warning hack out with a prettier hack. It's still a hack, but NSInvocation should be used, I'll be looking into this at some point :)

I've also changed the selectedIndex from int to NSUInteger to be uniform with the SDK types... Compiles without any hacks or build settings modifications now.
